### PR TITLE
Added the ability to save photos without loss of location and exif metadata, fixed several bugs

### DIFF
--- a/ImagePicker.podspec
+++ b/ImagePicker.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "ImagePicker"
   s.summary          = "Reinventing the way ImagePicker works."
-  s.version          = "3.1.0"
+  s.version          = `git describe --abbrev=0 --tags`
   s.homepage         = "https://github.com/hyperoslo/ImagePicker"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }

--- a/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ImagePicker.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/AssetManager.swift
+++ b/Source/AssetManager.swift
@@ -66,4 +66,32 @@ open class AssetManager {
     }
     return images
   }
+
+  open static func resolveAssets(_ assets: [PHAsset],imagesClosers: @escaping ([(imageData: Data, location: CLLocation?)])->()) {
+    let imageManager = PHImageManager.default()
+    let requestOptions = PHImageRequestOptions()
+    requestOptions.isSynchronous = true
+
+    var imagesData = [(imageData: Data,location: CLLocation?)]()
+
+    for asset in assets {
+      let options = PHContentEditingInputRequestOptions()
+      options.isNetworkAccessAllowed = true
+      asset.requestContentEditingInput(with: options) { (contentEditingInput: PHContentEditingInput?, _) -> Void in
+
+        let optionsRequest = PHImageRequestOptions()
+        optionsRequest.version = .original
+        optionsRequest.isSynchronous = true
+        imageManager.requestImageData(for: asset, options: optionsRequest, resultHandler: { (data, string, orientation, info) in
+          if let data = data {
+            imagesData.append((data, contentEditingInput!.location))
+            if (imagesData.count == assets.count) {
+              imagesClosers(imagesData)
+            }
+          }
+        })
+      }
+    }
+  }
+
 }

--- a/Source/BottomView/BottomContainerView.swift
+++ b/Source/BottomView/BottomContainerView.swift
@@ -98,10 +98,12 @@ open class BottomContainerView: UIView {
     } else {
       delegate?.doneButtonDidPress()
     }
+    self.isUserInteractionEnabled = false
   }
 
   @objc func handleTapGestureRecognizer(_ recognizer: UITapGestureRecognizer) {
     delegate?.imageStackViewDidPress()
+    self.isUserInteractionEnabled = false
   }
 
   fileprivate func animateImageView(_ imageView: UIImageView) {

--- a/Source/BottomView/ButtonPicker.swift
+++ b/Source/BottomView/ButtonPicker.swift
@@ -54,19 +54,19 @@ class ButtonPicker: UIButton {
 
   func subscribe() {
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidPush),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidPush),
+                                           object: nil)
 
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.imageDidDrop),
+                                           object: nil)
 
     NotificationCenter.default.addObserver(self,
-      selector: #selector(recalculatePhotosCount(_:)),
-      name: NSNotification.Name(rawValue: ImageStack.Notifications.stackDidReload),
-      object: nil)
+                                           selector: #selector(recalculatePhotosCount(_:)),
+                                           name: NSNotification.Name(rawValue: ImageStack.Notifications.stackDidReload),
+                                           object: nil)
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -81,6 +81,8 @@ class ButtonPicker: UIButton {
     accessibilityLabel = "Take photo"
     addTarget(self, action: #selector(pickerButtonDidPress(_:)), for: .touchUpInside)
     addTarget(self, action: #selector(pickerButtonDidHighlight(_:)), for: .touchDown)
+    addTarget(self, action: #selector(pickerButtonDidDragOutside(_:)), for: .touchDragOutside)
+
   }
 
   // MARK: - Actions
@@ -99,6 +101,11 @@ class ButtonPicker: UIButton {
 
   @objc func pickerButtonDidHighlight(_ button: UIButton) {
     numberLabel.textColor = UIColor.white
-    backgroundColor = UIColor(red: 0.3, green: 0.3, blue: 0.3, alpha: 1)
+    backgroundColor = UIColor(red:0.3, green:0.3, blue:0.3, alpha:1)
+  }
+
+  @objc func pickerButtonDidDragOutside(_ button: UIButton) {
+    numberLabel.textColor = UIColor.black
+    backgroundColor = UIColor.white
   }
 }

--- a/Source/CameraView/CameraMan.swift
+++ b/Source/CameraView/CameraMan.swift
@@ -210,12 +210,10 @@ class CameraMan {
         }
         if let attached = self.attachEXIFtoImage(image: imageData, EXIF: currentProperties) {
           do {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "Y-M-dd_HH-mm-ss"
-            let time = formatter.string(from: Date())
+
             let fileName = NSUUID().uuidString + "imagePicker.jpg"
             if let fullURL = NSURL.fileURL(withPathComponents: [NSTemporaryDirectory(), fileName]) {
-              try! attached.write(to: fullURL)
+              try attached.write(to: fullURL)
               let request = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: fullURL)
               request?.creationDate = Date()
               request?.location = location

--- a/Source/ImagePickerController.swift
+++ b/Source/ImagePickerController.swift
@@ -4,18 +4,15 @@ import Photos
 
 
 
-@objc public protocol ImagePickerDelegate: NSObjectProtocol {
+public protocol ImagePickerDelegate: NSObjectProtocol {
 
   func wrapperDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func doneButtonDidPress(_ imagePicker: ImagePickerController, images: [UIImage])
   func cancelButtonDidPress(_ imagePicker: ImagePickerController)
-
+  func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)])
+  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)])
 }
 
-extension ImagePickerDelegate {
-  func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)]) {}
-  func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)]) {}
-}
 
 
 open class ImagePickerController: UIViewController {
@@ -78,7 +75,7 @@ open class ImagePickerController: UIViewController {
 
   var volume = AVAudioSession.sharedInstance().outputVolume
 
-  @objc open weak var delegate: ImagePickerDelegate?
+  open weak var delegate: ImagePickerDelegate?
   open static var photoQuality: AVCaptureSession.Preset?
   open var stack = ImageStack()
   open var imageLimit = 0


### PR DESCRIPTION
Added the ability to save photos without loss of location and exif metadata
(Now the photo album stores the data. (which store the exif metadata and the gps coordinates) not UIImage.
If you set the quality of the photo (ImagePickerController.photoQuality = AVCaptureSession.Preset.photo), then after creating the snapshot, we will call the delegates
(func wrapperDidPress(images: [(imageData: Data,location: CLLocation?)])
func doneButtonDidPress(images: [(imageData: Data,location: CLLocation?)])), which will return the data. If the picture quality is not set in advance, the old delegate method will be called

Fixed bug when clicking and dragging(outside the photo button)

Fixed bugs when clicking the Done/Cancel/PhotoStack button again